### PR TITLE
Add support for French version

### DIFF
--- a/LegoIsland2Patcher/Form1.cs
+++ b/LegoIsland2Patcher/Form1.cs
@@ -74,6 +74,7 @@ namespace LegoIsland2Patcher
                                          createExeVersion("Spanish Version",      0xCF, "Isola LEGO 2.exe",  0x52FD, 7,  21, 0xA765, 0x3DFA0),
                                          createExeVersion("Dutch Version",        0x98, "LEGO eiland 2.exe", 0x52D6, 12, 31, 0xCAC3, 0x43C70),
                                          createExeVersion("German Version",       0x31, "LEGO Insel 2.exe",  0x52FD, 7,  21, 0xA765, 0x3E1A0),
+                                         createExeVersion("French Version",       0x81, "L'île LEGO 2.exe",  0x52FD, 7,  21, 0xA765, 0x3E1E0),
                                          createExeVersion("Unidentified Version", 0x52, "LEGO Island 2.exe", 0x529D, 7,  21, 0xA495, 0x2A870) };
 
             //If a known version was not found, default to the unidentified version


### PR DESCRIPTION
This adds support to the French version.

Tested with my own copy of the game
File name: `L'île LEGO 2.exe`
MD5: `AFF21A94A0036695D7E289CB435E4C29`
SHA1: `E9235FD89F29E7CBB42D8284BC0A5FDE0C97A847`
SHA256: `C0B45BEA4DC0704051A4478B64168E7C46580602AA12F96D9EE54CCC27F58167`